### PR TITLE
SM include - fix error 183: brackets after variable name indicates a fixed-size array, but size is missing or not constant

### DIFF
--- a/Pawn/includes/SteamWorks.inc
+++ b/Pawn/includes/SteamWorks.inc
@@ -270,9 +270,9 @@ typeset SteamWorksHTTPDataReceived
 
 typeset SteamWorksHTTPBodyCallback
 {
-	function void (const char sData[]);
-	function void (const char sData[], any value);
-	function void (const int data[], any value, int datalen);
+	function void (const char[] sData);
+	function void (const char[] sData, any value);
+	function void (const int[] data, any value, int datalen);
 };
 
 #else


### PR DESCRIPTION
Error 183: brackets after the variable name indicates a fixed-size array, but size is missing or not constant
please validate it.