### PR TITLE
Include 2 missing optionals

### DIFF
--- a/Pawn/includes/SteamWorks.inc
+++ b/Pawn/includes/SteamWorks.inc
@@ -333,6 +333,7 @@ public void __ext_SteamWorks_SetNTVOptional()
 	MarkNativeAsOptional("SteamWorks_IsLoaded");
 	MarkNativeAsOptional("SteamWorks_SetGameData");
 	MarkNativeAsOptional("SteamWorks_SetGameDescription");
+	MarkNativeAsOptional("SteamWorks_SetMapName");
 	MarkNativeAsOptional("SteamWorks_IsConnected");
 	MarkNativeAsOptional("SteamWorks_SetRule");
 	MarkNativeAsOptional("SteamWorks_ClearRules");
@@ -372,6 +373,7 @@ public void __ext_SteamWorks_SetNTVOptional()
 	MarkNativeAsOptional("SteamWorks_GetHTTPResponseBodyData");
 	MarkNativeAsOptional("SteamWorks_GetHTTPStreamingResponseBodyData");
 	MarkNativeAsOptional("SteamWorks_GetHTTPDownloadProgressPct");
+	MarkNativeAsOptional("SteamWorks_GetHTTPRequestWasTimedOut");
 	MarkNativeAsOptional("SteamWorks_SetHTTPRequestRawPostBody");
 	MarkNativeAsOptional("SteamWorks_SetHTTPRequestRawPostBodyFromFile");
 


### PR DESCRIPTION
Hi!

@nickdnk and I have been working on get5 for the past while here, and noticed that there were a few optional natives misisng from the Pawn includes. After the Sourcemod 11 update, plenty of these were added, which is great! However, I believe the few extra includes here are needed to expand functionality when using SteamWorks in other projects.

If these can not be included, would you mind letting us know why? I believe we wanted to use `SteamWorks_GetHTTPRequestWasTimedOut`, but opted for a different approach. However, this optional would be a nice to have so plugins don't crash when it gets used.

Thanks!